### PR TITLE
Improve UI theme contrast

### DIFF
--- a/src/frontend/ai-chatbot/src/app/globals.css
+++ b/src/frontend/ai-chatbot/src/app/globals.css
@@ -2,7 +2,8 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
+    /* Light theme colors */
+    --background: 0 0% 97%;
     --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
@@ -18,16 +19,17 @@
     --accent-foreground: 222.2 84% 4.9%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
+    --border: 214.3 31.8% 90%;
     --input: 214.3 31.8% 91.4%;
     --ring: 221.2 83.2% 53.3%;
     --radius: 0.5rem;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
+    /* Dark theme colors */
+    --background: 220 5% 10%;
     --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
+    --card: 220 5% 14%;
     --card-foreground: 210 40% 98%;
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;

--- a/src/frontend/ai-chatbot/src/components/layout/PageLayout.tsx
+++ b/src/frontend/ai-chatbot/src/components/layout/PageLayout.tsx
@@ -16,7 +16,7 @@ export function PageLayout({
   return (
     <div className={cn("h-full w-full grid grid-rows-[auto_1fr_auto] overflow-hidden", className)}>
       {header && (
-        <header className="w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <header className="w-full border-b border-border/70 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
           {header}
         </header>
       )}
@@ -26,7 +26,7 @@ export function PageLayout({
       </main>
       
       {footer && (
-        <footer className="border-t bg-background">
+        <footer className="border-t border-border/70 bg-background">
           {footer}
         </footer>
       )}

--- a/src/frontend/ai-chatbot/src/components/ui/avatar.tsx
+++ b/src/frontend/ai-chatbot/src/components/ui/avatar.tsx
@@ -37,7 +37,7 @@ const AvatarFallback = React.forwardRef<
   <AvatarPrimitive.Fallback
     ref={ref}
     className={cn(
-      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      "flex h-full w-full items-center justify-center rounded-full bg-primary/20",
       className
     )}
     {...props}

--- a/src/frontend/ai-chatbot/src/components/ui/button.tsx
+++ b/src/frontend/ai-chatbot/src/components/ui/button.tsx
@@ -9,15 +9,15 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background hover:bg-muted hover:text-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/70",
+        ghost: "hover:bg-muted hover:text-foreground",
+        link: "text-primary underline-offset-4 hover:text-primary/80",
       },
       size: {
         default: "h-10 px-4 py-2",


### PR DESCRIPTION
## Summary
- soften light and dark theme backgrounds
- tweak button hover and ghost/link variants for more contrast
- give avatars a primary tinted fallback background
- lighten header and footer separators

## Testing
- `npm run lint` *(fails: next not found, then after installing deps, passes)*
- `node test-chat-endpoint.js` *(fails: fetch failed)*
- `node test-conversation-flow.js` *(fails: fetch failed)*
- `node test-foundry-agent.js` *(fails: fetch failed)*
- `node test-streaming-chat.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6864850ce750832f9a76e8b7a3f8a490