### PR TITLE
Add prompt for generating a new React form component with guidelines and requirements

### DIFF
--- a/.github/prompts/prompts.prompt.md
+++ b/.github/prompts/prompts.prompt.md
@@ -1,0 +1,20 @@
+---
+mode: 'agent'
+model: GPT-4o
+tools: ['githubRepo', 'codebase']
+description: 'Generate a new React form component'
+---
+Your goal is to generate a new React form component based on the templates in #githubRepo contoso/react-templates.
+
+Ask for the form name and fields if not provided.
+
+Requirements for the form:
+* Use form design system components: [design-system/Form.md](../docs/design-system/Form.md)
+* Use `react-hook-form` for form state management:
+* Always define TypeScript types for your form data
+* Prefer *uncontrolled* components using register
+* Use `defaultValues` to prevent unnecessary rerenders
+* Use `yup` for validation:
+* Create reusable validation schemas in separate files
+* Use TypeScript types to ensure type safety
+* Customize UX-friendly validation rules


### PR DESCRIPTION
This pull request introduces a new prompt configuration for generating React form components using best practices and specific tools. The prompt is designed to guide the user in creating forms efficiently with a focus on maintainability and type safety.

### New prompt configuration:

* [`.github/prompts/prompts.prompt.md`](diffhunk://#diff-d9b62c738cd88d0cefa6aa02629b7409c34c426572127712d994e35c764be136R1-R20): Added a new prompt with the `agent` mode and `GPT-4o` model, specifying tools like `githubRepo` and `codebase`. The prompt includes detailed requirements for generating React forms, such as using `react-hook-form` for state management, TypeScript for type safety, and `yup` for validation. It also emphasizes using the design system components and creating reusable validation schemas.