### PR TITLE
Update OpenAPIBaseUrl to use localhost for local development

### DIFF
--- a/src/backend/FleetAssistant.WebApi/api-test.http
+++ b/src/backend/FleetAssistant.WebApi/api-test.http
@@ -12,3 +12,18 @@ Content-Type: application/json
         }
     ]
 }
+
+###
+
+PO1ST https://localhost:7074/api/chat
+Content-Type: application/json
+
+{
+    "messages": [
+        {
+            "id": "1",
+            "role": "user",
+            "content": "Hello, how can I assist you today?"
+        }
+    ]
+}

--- a/src/backend/FleetAssistant.WebApi/api-test.http
+++ b/src/backend/FleetAssistant.WebApi/api-test.http
@@ -15,7 +15,7 @@ Content-Type: application/json
 
 ###
 
-PO1ST https://localhost:7074/api/chat
+POST https://localhost:7074/api/chat
 Content-Type: application/json
 
 {

--- a/src/backend/FleetAssistant.WebApi/appsettings.json
+++ b/src/backend/FleetAssistant.WebApi/appsettings.json
@@ -15,7 +15,7 @@
     "AllowedExtensions": [".pdf", ".doc", ".docx", ".txt", ".jpg", ".jpeg", ".png", ".gif", ".xlsx", ".csv"]
   },
   "UseFoundryAgent": true,
-  "OpenAPIBaseUrl": "https://fleetassistant.azurewebsites.net",
+  "OpenAPIBaseUrl": "https://localhost:7074",
   "FoundryAgentService": {
     "AgentId": "YOUR_AGENT_ID_HERE",
     "AgentEndpoint": "YOUR_FOUNDRY_AGENT_ENDPOINT_HERE",


### PR DESCRIPTION
This pull request makes minor configuration and test updates to support local development and API testing.

Configuration updates:

* Updated the `OpenAPIBaseUrl` in `appsettings.json` to use the local server URL (`https://localhost:7074`) for local development and testing.

Testing improvements:

* Added a new HTTP request example for the `/api/chat` endpoint in `api-test.http` to facilitate local API testing.