### PR TITLE
Change CODEOWNERS for JavaScript files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Path Pattern        Owners
 /src/backend/*        @kwkraus
 /src/frontend/*       @ckriutz
-/src/**/*.js          @kwkraus
+/src/**/*.js          @TeplrGuy


### PR DESCRIPTION
This pull request makes a small update to the `.github/CODEOWNERS` file, reassigning ownership of all JavaScript files in the `src` directory to a new owner.