### PR TITLE
Add review comment to .gitignore

### DIFF
--- a/src/backend/.gitignore
+++ b/src/backend/.gitignore
@@ -5,6 +5,8 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Casey Kriutzfield must review this line
+
 # User-specific files
 *.rsuser
 *.suo


### PR DESCRIPTION
This pull request makes a minor update to the `.gitignore` file in the `src/backend` directory. The change adds a comment indicating that Casey Kriutzfield must review a specific line.

([src/backend/.gitignoreR8-R9](diffhunk://#diff-e245ecf64f998b3fa4a4b54e1c98bca99e5ae4205529fc00d4af3af10be6da6aR8-R9))Added a comment indicating that Casey Kriutzfield must review the line.