### PR TITLE
fix: Adjust position of message action buttons for assistant messages

### DIFF
--- a/src/frontend/ai-chatbot/src/components/chat/ChatMessage.tsx
+++ b/src/frontend/ai-chatbot/src/components/chat/ChatMessage.tsx
@@ -190,7 +190,7 @@ export function ChatMessage({ message, isLastMessage, className }: ChatMessagePr
 
           {/* Message Actions (Show on hover for assistant messages) */}
           {isAssistant && (
-            <div className="absolute -bottom-8 left-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+            <div className="absolute -bottom-8 right-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
               <div className="flex items-center space-x-1">
                 <Button
                   variant="ghost"


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the `ChatMessage` component. The action buttons for assistant messages are now aligned to the right instead of the left when they appear on hover.

* UI adjustment:
  * Changed the alignment of the assistant message action buttons from the left to the right in the `ChatMessage` component (`src/frontend/ai-chatbot/src/components/chat/ChatMessage.tsx`).